### PR TITLE
reverting disabling of bod

### DIFF
--- a/src/config/config.sample.json
+++ b/src/config/config.sample.json
@@ -5,7 +5,7 @@
   "data_path": "",
   "cycle_pages": "false",
   "components": {
-    "bod": false,
+    "bod": true,
     "cybex": true,
     "dashboard": true,
     "hiringdashboard": false,


### PR DESCRIPTION
Their are dependencies that require bod be enabled or cybex and other sections will fail