### PR TITLE
Fix failing deployment and add some maintenance updates

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "bower_components",
+  "registry": "https://bower.herokuapp.com"
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,3 +98,9 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build the Docker Compose configuration
+        run: make dev-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         # formatting changes that cause failures when used with a JavaScript project
         # as old as this one
         additional_dependencies:
-          - "prettier@2.8.7"
+          - "prettier@2.8.8"
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.30.0
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update --quiet --quiet \
     && rm --recursive --force /var/lib/apt/lists/*
 
 # Set up the application directory
-RUN mkdir -p /usr/src/app
+RUN mkdir --parents /usr/src/app
 WORKDIR /usr/src/app
 
 # Install application dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,17 @@ LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV PATH="${PATH}:/usr/src/app/node_modules/.bin/"
 
+# Update the apt SourceList now that Debian Stretch's packages have been archived
+RUN printf "deb http://archive.debian.org/debian stretch main\ndeb http://archive.debian.org/debian-security stretch/updates main\n" > /etc/apt/sources.list
+
+# Update system packages. The latest node:6 image available was created before
+# Debian Stretch support ended completely. This will ensure we have the latest
+# package versions available.
+RUN apt-get update --quiet --quiet \
+    && apt-get upgrade --quiet --quiet \
+    && apt-get clean --quiet --quiet \
+    && rm --recursive --force /var/lib/apt/lists/*
+
 # Set up the application directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Install application dependencies
-COPY package.json bower.json Makefile ./
+COPY bower.json Makefile npm-shrinkwrap.json package.json ./
 RUN make install
 
 # Add application code

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Install application dependencies
-COPY bower.json Makefile npm-shrinkwrap.json package.json ./
+COPY .bowerrc bower.json Makefile npm-shrinkwrap.json package.json ./
 RUN make install
 
 # Add application code

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ dev: install gulp build-dev
 
 build: install install-config
 	ng build --prod
-	find dist -type f -print0 | sort -z | xargs -0 shasum | shasum > dist/config/app.version
+	find dist -type f -print0 | sort --zero-terminated | xargs --null shasum | shasum > dist/config/app.version
 
 build-dev: install-config
-	find src -type f -print0 | sort -z | xargs -0 shasum | shasum > src/config/app.version
+	find src -type f -print0 | sort --zero-terminated | xargs --null shasum | shasum > src/config/app.version
 
 install:
 	npm install
@@ -21,21 +21,21 @@ gulp: install
 	gulp
 
 install-config:
-	cp -n src/config/config.sample.json src/config/config.json || :
+	cp --no-clobber src/config/config.sample.json src/config/config.json || :
 
 dev-build:
 	docker compose build
 
 dev-start:
-	docker compose up -d
+	docker compose up --detach
 
 dev-shell:
 	# Use $$ to properly escape $ for makefile
-	docker exec -it $$(docker ps | grep 0.0.0.0:4200 | awk '{print $$1}') /bin/bash
+	docker exec --interactive --tty $$(docker ps | grep 0.0.0.0:4200 | awk '{print $$1}') /bin/bash
 
 dev-logs:
 	# Use $$ to properly escape $ for makefile
-	docker logs -f $$(docker ps | grep 0.0.0.0:4200 | awk '{print $$1}')
+	docker logs --follow $$(docker ps | grep 0.0.0.0:4200 | awk '{print $$1}')
 
 dev-rebuild: dev-clean dev-build
 
@@ -43,16 +43,16 @@ dev-stop:
 	docker compose down
 
 dev-clean:
-	docker compose down -v --rmi local
+	docker compose down --volumes --rmi local
 
 docker-web-server:
 	# create the dist directory
 	docker compose run --rm client make build
 	# copy the dist director into a docker image
-	docker build -t ncats/cyhy-web-server -f ./Dockerfile_dist .
+	docker build --tag ncats/cyhy-web-server --file ./Dockerfile_dist .
 
 clean:
-	rm -rf ./bower_components
-	rm -rf ./src/assets/bower
-	rm -rf ./node_modules
-	rm -rf ./dist
+	rm --recursive --force ./bower_components
+	rm --recursive --force ./src/assets/bower
+	rm --recursive --force ./node_modules
+	rm --recursive --force ./dist

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,8 +22,8 @@ case "$1" in
   build)
     echo "Building to dist/ ..."
     make build
-    mkdir -p /usr/src/build
-    cp -r dist /usr/src/build
+    mkdir --parents /usr/src/build
+    cp --recursive dist /usr/src/build
     ;;
   start)
     echo "Starting up development server..."

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "@types/selenium-webdriver": {
+      "from": "@types/selenium-webdriver@2.53.47",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.47.tgz",
+      "version": "2.53.47"
+    }
+  },
+  "name": "exam",
+  "version": "0.0.0"
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request makes some adjustments to ensure that a deployment of this configuration in the [CyHy VS environment](https://github.com/cisagov/cyhy_amis) is successful. This is done primarily through adding a `npm-shrinkwrap.json` file that pins the version of a dependency in the dependency tree. This pull request also adds the following:
- A `.bowerrc` file to point to a legacy endpoint for [bower] as a certificate in its current TLS certificate chain is expired on this image.
- Adds updating the system packages on the base image (`node:6`) to the Dockerfile.
- Updates the version of [prettier] in the [pre-commit] configuration.
- Update some command usages to prefer long switches.
- Adds a _very_ basic `build` job to the `build` GitHub Actions workflow.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The latest [2.x release of the `@types/selenium-webdriver` package](https://www.npmjs.com/package/@types/selenium-webdriver/v/2.53.48) causes an error during `npm install` when the Docker image in this configuration tries to build. Running `npm shrinkwrap` in a previous build that was locally cached on my machine does not produce a version pin for this package. Instead I manually crafted a suitable `npm-shrinkwrap.json` file that contains the necessary version pin. I also found that some combination of system package, [Node.js], and [bower] versions result in the following error:

```log
#0 172.7 bower --allow-root install
#0 173.8 bower c3#^0.4.11      CERT_HAS_EXPIRED Request to https://registry.bower.io/packages/c3 failed: certificate has expired
#0 173.8 make: *** [install] Error 1
#0 173.8 Makefile:17: recipe for target 'install' failed
```

Once I created the workaround `.bowerrc` file I verified that the Docker image was able to build successfully.

The last build of the `node:6` Docker image used as the base image for this configuration was well before support for Debian Stretch ended completely. As a result the system packages are out-of-date when building a Docker image. The Dockerfile was updated to replace the apt SourceList with functional entries due to Debian Stretch's packages being moved to the Debian Archive. Additionally the Dockerfile was updated to upgrade any of the already installed system packages.

Lastly a very basic job that verifies that the image can build successfully will at least provided cursory verification that the configuration is still functional.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that this image builds and a cursory check of functionality when deployed was successful.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[bower]: https://github.com/bower/bower
[Node.js]: https://github.com/nodejs/node
[pre-commit]: https://github.com/pre-commit/pre-commit
[prettier]: https://github.com/prettier/prettier
