### PR TITLE
Get yarn public key via https rather than via GPG keyserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,8 @@ ENV YARN_VERSION 1.22.19
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && curl --compressed --fail --location --output yarn-pubkey.gpg --show-error --silent "https://dl.yarnpkg.com/debian/pubkey.gpg" \
+  && test "$(gpg --show-keys --with-colons yarn-pubkey.gpg | awk -F: '$5=="1646B01B86E50310" { getline; print $10; exit }')" = "72ECF46A56B4AD39C907BBB71646B01B86E50310" \
   && gpg --batch --import yarn-pubkey.gpg \
-  && test "$(gpg --batch --with-colons --fingerprint 1646B01B86E50310 | awk -F: '$1=="fpr" { print $10; exit }')" = "72ECF46A56B4AD39C907BBB71646B01B86E50310" \
   && curl --compressed --fail --location --remote-name --show-error --silent "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl --compressed --fail --location --remote-name --show-error --silent "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
   && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,12 +77,7 @@ RUN addgroup -g 1000 node \
 ENV YARN_VERSION 1.22.19
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
+  && curl -fsSL --compressed "https://dl.yarnpkg.com/debian/pubkey.gpg" | gpg --batch --import \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
   && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,9 @@ RUN addgroup -g 1000 node \
 ENV YARN_VERSION 1.22.19
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
-  && curl -fsSL --compressed "https://dl.yarnpkg.com/debian/pubkey.gpg" | gpg --batch --import \
+  && curl --compressed --fail --location --output yarn-pubkey.gpg --show-error --silent  "https://dl.yarnpkg.com/debian/pubkey.gpg" \
+  && gpg --batch --import yarn-pubkey.gpg \
+  && test "$(gpg --batch --with-colons --fingerprint 1646B01B86E50310 | awk -F: '$1=="fpr" { print $10; exit }')" = "72ECF46A56B4AD39C907BBB71646B01B86E50310" \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
   && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
@@ -85,7 +87,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && rm yarn-pubkey.gpg yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test
   && yarn --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN addgroup -g 1000 node \
       esac \
   && if [ -n "${CHECKSUM}" ]; then \
     set -eu; \
-    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    curl --compressed --fail --location --remote-name --show-error --silent "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
     echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
       && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
       && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
@@ -54,8 +54,8 @@ RUN addgroup -g 1000 node \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
     done \
-    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
-    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && curl --compressed --fail --location --remote-name --show-error --silent "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl --compressed --fail --location --remote-name --show-error --silent "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
     && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
     && tar -xf "node-v$NODE_VERSION.tar.xz" \
@@ -77,11 +77,11 @@ RUN addgroup -g 1000 node \
 ENV YARN_VERSION 1.22.19
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
-  && curl --compressed --fail --location --output yarn-pubkey.gpg --show-error --silent  "https://dl.yarnpkg.com/debian/pubkey.gpg" \
+  && curl --compressed --fail --location --output yarn-pubkey.gpg --show-error --silent "https://dl.yarnpkg.com/debian/pubkey.gpg" \
   && gpg --batch --import yarn-pubkey.gpg \
   && test "$(gpg --batch --with-colons --fingerprint 1646B01B86E50310 | awk -F: '$1=="fpr" { print $10; exit }')" = "72ECF46A56B4AD39C907BBB71646B01B86E50310" \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && curl --compressed --fail --location --remote-name --show-error --silent "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl --compressed --fail --location --remote-name --show-error --silent "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
   && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && mkdir -p /opt \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the way the Yarn GPG public key is imported in the `Dockerfile` to improve reliability and security. Instead of retrieving the key from multiple keyservers, it now fetches the official Yarn GPG key directly from their website.

**Build process improvements:**

* Changed the Yarn GPG key import step to fetch the key directly from the official Yarn website using `curl`, replacing the previous approach of retrieving the key from multiple keyservers.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The old way was failing with an error like this:

```
"#7 [web-server base-image
│ 3/4] RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar   && for key in     6A010C5166006599AA17F08146C2130DFD2497F5   ; do     gpg --batch --keyserver hkps://keys.openpgp.org
│ --recv-keys \"$key\" ||     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \"$key\" ;   done   && curl -fsSLO --compressed
│ \"https://yarnpkg.com/downloads/1.22.19/yarn-v1.22.19.tar.gz\"   && curl -fsSLO --compressed \"https://yarnpkg.com/downloads/1.22.19/yarn-v1.22.19.tar.gz.asc\"   && gpg --batch --verify
│ yarn-v1.22.19.tar.gz.asc yarn-v1.22.19.tar.gz   && mkdir -p /opt   && tar -xzf yarn-v1.22.19.tar.gz -C /opt/   && ln -s /opt/yarn-v1.22.19/bin/yarn /usr/local/bin/yarn   && ln -s
│ /opt/yarn-v1.22.19/bin/yarnpkg /usr/local/bin/yarnpkg   && rm yarn-v1.22.19.tar.gz.asc yarn-v1.22.19.tar.gz   && apk del .build-deps-yarn   && yarn --version", "#7 0.304 fetch
│ https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz", "#7 0.587 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz", "#7 0.964 (1/38)
│ Installing ca-certificates (20240226-r0)", "#7 0.991 (2/38) Installing brotli-libs (1.0.9-r9)", "#7 1.023 (3/38) Installing nghttp2-libs (1.51.0-r2)", "#7 1.037 (4/38) Installing libcurl
│ (8.9.0-r0)", "#7 1.062 (5/38) Installing curl (8.9.0-r0)", "#7 1.078 (6/38) Installing libgpg-error (1.46-r1)", "#7 1.092 (7/38) Installing libassuan (2.5.6-r0)", "#7 1.104 (8/38) Installing
│ ncurses-terminfo-base (6.3_p20221119-r1)", "#7 1.116 (9/38) Installing ncurses-libs (6.3_p20221119-r1)", "#7 1.136 (10/38) Installing pinentry (1.2.1-r0)", "#7 1.148 Executing
│ pinentry-1.2.1-r0.post-install", "#7 1.150 (11/38) Installing libgcrypt (1.10.1-r0)", "#7 1.180 (12/38) Installing gnupg-gpgconf (2.2.40-r0)", "#7 1.197 (13/38) Installing libbz2 (1.0.8-r4)",
│ "#7 1.209 (14/38) Installing sqlite-libs (3.40.1-r1)", "#7 1.241 (15/38) Installing gpg (2.2.40-r0)", "#7 1.267 (16/38) Installing npth (1.6-r2)", "#7 1.278 (17/38) Installing gpg-agent
│ (2.2.40-r0)", "#7 1.300 (18/38) Installing gpg-wks-server (2.2.40-r0)", "#7 1.318 (19/38) Installing libksba (1.6.4-r0)", "#7 1.333 (20/38) Installing gpgsm (2.2.40-r0)", "#7 1.350 (21/38)
│ Installing gpgv (2.2.40-r0)", "#7 1.368 (22/38) Installing gmp (6.2.1-r2)", "#7 1.386 (23/38) Installing nettle (3.8.1-r0)", "#7 1.408 (24/38) Installing libffi (3.4.4-r0)", "#7 1.419 (25/38)
│ Installing p11-kit (0.24.1-r1)", "#7 1.439 (26/38) Installing libtasn1 (4.19.0-r0)", "#7 1.451 (27/38) Installing libunistring (1.1-r0)", "#7 1.486 (28/38) Installing gnutls (3.7.8-r3)", "#7
│ 1.523 (29/38) Installing gdbm (1.23-r0)", "#7 1.534 (30/38) Installing libsasl (2.1.28-r3)", "#7 1.547 (31/38) Installing libldap (2.6.3-r6)", "#7 1.567 (32/38) Installing gnupg-dirmngr
│ (2.2.40-r0)", "#7 1.586 (33/38) Installing gnupg-utils (2.2.40-r0)", "#7 1.603 (34/38) Installing gnupg-wks-client (2.2.40-r0)", "#7 1.616 (35/38) Installing gnupg (2.2.40-r0)", "#7 1.627
│ (36/38) Installing libacl (2.3.1-r1)", "#7 1.639 (37/38) Installing tar (1.34-r2)", "#7 1.657 (38/38) Installing .build-deps-yarn (20260611.200054)", "#7 1.657 Executing
│ busybox-1.35.0-r31.trigger", "#7 1.660 Executing ca-certificates-20240226-r0.trigger", "#7 1.715 OK: 27 MiB in 55 packages", "#7 1.764 gpg: directory '/root/.gnupg' created", "#7 1.764 gpg:
│ keybox '/root/.gnupg/pubring.kbx' created", "#7 2.651 gpg: key 1646B01B86E50310: no user ID", "#7 2.651 gpg: Total number processed: 1", "#7 32.87 gpg: keyserver receive failed: Operation
│ timed out", "#7 ERROR: process \"/bin/sh -c apk add --no-cache --virtual .build-deps-yarn curl gnupg tar   && for key in     6A010C5166006599AA17F08146C2130DFD2497F5   ; do     gpg --batch
│ --keyserver hkps://keys.openpgp.org --recv-keys \\\"$key\\\" ||     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \\\"$key\\\" ;   done   && curl -fsSLO --compressed
│ \\\"https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz\\\"   && curl -fsSLO --compressed \\\"https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc\\\"
│ && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz   && mkdir -p /opt   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/   && ln -s
│ /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
│ && apk del .build-deps-yarn   && yarn --version\" did not complete successfully: exit code: 2", "------", " > [web-server base-image 3/4] RUN apk add --no-cache --virtual .build-deps-yarn curl
│ gnupg tar   && for key in     6A010C5166006599AA17F08146C2130DFD2497F5   ; do     gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys \"$key\" ||     gpg --batch --keyserver
│ keyserver.ubuntu.com --recv-keys \"$key\" ;   done   && curl -fsSLO --compressed \"https://yarnpkg.com/downloads/1.22.19/yarn-v1.22.19.tar.gz\"   && curl -fsSLO --compressed
│ \"https://yarnpkg.com/downloads/1.22.19/yarn-v1.22.19.tar.gz.asc\"   && gpg --batch --verify yarn-v1.22.19.tar.gz.asc yarn-v1.22.19.tar.gz   && mkdir -p /opt   && tar -xzf yarn-v1.22.19.tar.gz
│ -C /opt/   && ln -s /opt/yarn-v1.22.19/bin/yarn /usr/local/bin/yarn   && ln -s /opt/yarn-v1.22.19/bin/yarnpkg /usr/local/bin/yarnpkg   && rm yarn-v1.22.19.tar.gz.asc yarn-v1.22.19.tar.gz   &&
│ apk del .build-deps-yarn   && yarn --version:", "1.639 (37/38) Installing tar (1.34-r2)", "1.657 (38/38) Installing .build-deps-yarn (20260611.200054)", "1.657 Executing
│ busybox-1.35.0-r31.trigger", "1.660 Executing ca-certificates-20240226-r0.trigger", "1.715 OK: 27 MiB in 55 packages", "1.764 gpg: directory '/root/.gnupg' created", "1.764 gpg: keybox
│ '/root/.gnupg/pubring.kbx' created", "2.651 gpg: key 1646B01B86E50310: no user ID", "2.651 gpg: Total number processed: 1", "32.87 gpg: keyserver receive failed: Operation timed out",
│ "------"]}
```

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this, I built a dev AMI and deployed it to my dev CyHy environment.  I then confirmed that the dashboard started up successfully and displayed data.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

